### PR TITLE
check for active scope

### DIFF
--- a/Configuration/NodeSearchConfiguration.php
+++ b/Configuration/NodeSearchConfiguration.php
@@ -161,7 +161,7 @@ class NodeSearchConfiguration implements SearchConfigurationInterface
 
                     $content = '';
                     if ($page instanceof HasPagePartsInterface) {
-                        if (!$this->container->hasScope('request')) {
+                        if (!$this->container->isScopeActive('request')) {
                             $this->container->enterScope('request');
                             $request = new Request();
                             $request->setLocale($nodeTranslation->getLang());


### PR DESCRIPTION
Check if the scope is active. Even if you have a scope request it does not mean that it is active. If it is not active the kuma:search:populate throws error "You cannot create a service ("templating.helper.assets") of an inactive scope ("request")."
